### PR TITLE
feat: create Combo Select

### DIFF
--- a/src/Components/ComboSelect.jsx
+++ b/src/Components/ComboSelect.jsx
@@ -1,0 +1,40 @@
+import { Combobox, useCombobox } from "@mantine/core";
+
+export const ComboSelect = ({
+  data,
+  onChange,
+  renderTargetButton,
+  maxHeight = 200,
+  width = 250,
+}) => {
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  });
+
+  const options = data.map(({ value, label }) => (
+    <Combobox.Option value={value} key={value}>
+      {label}
+    </Combobox.Option>
+  ));
+
+  return (
+    <Combobox
+      store={combobox}
+      width={width}
+      onOptionSubmit={(val) => {
+        onChange(val);
+        combobox.closeDropdown();
+      }}
+    >
+      <Combobox.Target>
+        {renderTargetButton(combobox.toggleDropdown)}
+      </Combobox.Target>
+
+      <Combobox.Dropdown>
+        <Combobox.Options mah={maxHeight} style={{ overflowY: "auto" }}>
+          {options}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+};


### PR DESCRIPTION
**Created Combo Select component**

This component allows for custom placeholder customization for the Select. The default Select from Mantine UI has limitations when it comes to customization, but the library provides a component that enables building your own Select, where you can add any elements you need to fit your desired design.

Here is a screenshot from [Mantine UI documentation](https://mantine.dev/core/select/)

![image](https://github.com/user-attachments/assets/b6d014bd-7c78-454f-84ea-5c70fc1f09b9)



![image](https://github.com/user-attachments/assets/23e68471-c944-4073-b485-31ea1fadea9c)
