### PR TITLE
fix: sidebar hide lead modal

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@
 
 <!-- Step-by-step instructions for how reviewers can verify these changes work as expected. -->
 
+## :📸 Relevant Screenshot
+
 ## 🔖 Further reading
 
 - [Trello task](link)

--- a/src/Components/LeadsComponent/LeadsComponent.js
+++ b/src/Components/LeadsComponent/LeadsComponent.js
@@ -9,7 +9,6 @@ import { LeadTable } from "./LeadTable";
 import { useDebounce, useConfirmPopup } from "../../hooks";
 import { showServerError, getTotalPages, getLanguageByKey } from "../utils";
 import { api } from "../../api";
-import { Modal } from "../Modal";
 import SingleChat from "../ChatComponent/SingleChat";
 import { Spin } from "../Spin";
 import { RefLeadsFilter } from "./LeadsFilter";
@@ -330,18 +329,14 @@ const Leads = () => {
 
       {spinnerTickets && <SpinnerRightBottom />}
 
-      <Modal
-        open={isChatOpen}
+      <MantineModal
+        fullScreen
+        open={isChatOpen && ticketId}
         onClose={closeChatModal}
-        width={1850}
-        height={1000}
-        footer={null}
-        showCloseButton={false}
+        height="calc(100% - 60px)"
       >
-        {ticketId && (
-          <SingleChat ticketId={ticketId} onClose={closeChatModal} />
-        )}
-      </Modal>
+        <SingleChat ticketId={ticketId} onClose={closeChatModal} />
+      </MantineModal>
 
       {isOpenAddLeadModal && (
         <TicketModal

--- a/src/Components/MantineModal.jsx
+++ b/src/Components/MantineModal.jsx
@@ -5,17 +5,18 @@ export const MantineModal = ({
   open,
   title,
   onClose,
-  footer,
+  height = "700px",
+  size = 700,
   ...props
 }) => {
   return (
     <Modal
       centered
-      size="700"
+      size={size}
       opened={open}
       onClose={onClose}
       styles={{
-        body: { height: "700px" },
+        body: { height: `${height}` },
       }}
       title={
         <Text size="xl" fw="bold">


### PR DESCRIPTION
## ✅ What

<!-- A brief description of the changes in this PR. -->

When opening a lead from the leads page, the sidebar overlaps and partially hides the modal. Initially, the modal was custom-built from scratch. However, since the project now uses the Mantine UI library, the custom modal has been replaced with Mantine’s built-in modal component to fix the issue.

## 🤔 Why

<!-- A brief description of the reason for these changes. -->


## 🔖 Further reading

- [Trello task](https://trello.com/c/cuOK4CYc/160-leads-on-click-modal-display-is-incorrect-go-back-does-not-reset-modal)
