### PR TITLE
fix: overflow contact inside chat items

### DIFF
--- a/src/Components/ChatComponent/components/ChatListItem/ChatListItem.jsx
+++ b/src/Components/ChatComponent/components/ChatListItem/ChatListItem.jsx
@@ -19,6 +19,7 @@ export const ChatListItem = ({
         py="10px"
         pr="16px"
         pl="24px"
+        w="100%"
         key={chat.id}
         className={`chat-item ${chat.id === selectTicketId ? "active" : ""} pointer`}
         onClick={() => onHandleTicketClick(chat.id)}
@@ -32,7 +33,7 @@ export const ChatListItem = ({
             </Badge>
           </Box>
         )}
-        <Flex gap="12" align="center">
+        <Flex gap="12" align="center" w="100%">
           <Image
             w={36}
             h={36}
@@ -40,8 +41,11 @@ export const ChatListItem = ({
             src={chat?.photo_url ? chat.photo_url : DEFAULT_PHOTO}
             fallbackSrc={DEFAULT_PHOTO}
           />
-          <div>
-            <Text>{chat.contact ? chat.contact : "-"}</Text>
+          <Box w="100%">
+            <Box w="75%">
+              <Text truncate>{chat.contact ? chat.contact : "-"}</Text>
+            </Box>
+
             <Flex gap="12">
               <Flex align="center" gap="4">
                 <FaFingerprint />
@@ -52,7 +56,7 @@ export const ChatListItem = ({
               <Divider orientation="vertical" />
               <Tag type={priorityTagColors[chat.priority]}>{chat.priority}</Tag>
             </Flex>
-          </div>
+          </Box>
         </Flex>
 
         <Flex justify="space-between" gap="6">

--- a/src/Components/ChatComponent/components/ChatListItem/ChatListItem.jsx
+++ b/src/Components/ChatComponent/components/ChatListItem/ChatListItem.jsx
@@ -19,7 +19,6 @@ export const ChatListItem = ({
         py="10px"
         pr="16px"
         pl="24px"
-        w="100%"
         key={chat.id}
         className={`chat-item ${chat.id === selectTicketId ? "active" : ""} pointer`}
         onClick={() => onHandleTicketClick(chat.id)}
@@ -41,10 +40,9 @@ export const ChatListItem = ({
             src={chat?.photo_url ? chat.photo_url : DEFAULT_PHOTO}
             fallbackSrc={DEFAULT_PHOTO}
           />
-          <Box w="100%">
-            <Box w="75%">
-              <Text truncate>{chat.contact ? chat.contact : "-"}</Text>
-            </Box>
+
+          <Box w="75%">
+            <Text truncate>{chat.contact ? chat.contact : "-"}</Text>
 
             <Flex gap="12">
               <Flex align="center" gap="4">


### PR DESCRIPTION
## ✅ What

When the contact title is too long, it wraps to a new line and looks messy. This update ensures the title stays on a single line and displays an ellipsis (…) if it overflows.
<!-- A brief description of the changes in this PR. -->


## :📸 Relevant Screenshot

Before: 

![image](https://github.com/user-attachments/assets/b5591d07-9d16-4c0d-bca9-480cca2335ca)


After: 

![image](https://github.com/user-attachments/assets/421109e7-230e-4c86-b497-25032105602a)


## 🔖 Further reading

- [CHAT LIST: THE CHAT LIST TITLE MUST BE DISPLAYED ON A SINGLE LINE](https://trello.com/c/8PtwW3sM/190-chat-list-title-for-chat-list-must-be-in-one-single-line)
