### PR TITLE
fix: change font size for chat extra info tabs

### DIFF
--- a/src/Components/ChatComponent/ChatExtraInfo.js
+++ b/src/Components/ChatComponent/ChatExtraInfo.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { MdOutlineAirplaneTicket } from "react-icons/md";
 import { enqueueSnackbar } from "notistack";
 import { Tabs, ScrollArea, Divider, Box, Button, Text } from "@mantine/core";
 import { getLanguageByKey, showServerError } from "../utils";
@@ -178,11 +179,12 @@ const ChatExtraInfo = ({
       <Tabs defaultValue="general" h="100%">
         <Tabs.List>
           <Tabs.Tab value="general">
-            <Text>{getLanguageByKey("General")}</Text>
+            <Text size="xs">{getLanguageByKey("General")}</Text>
           </Tabs.Tab>
           <Tabs.Tab value="info">
             <Box w="100">
               <Text
+                size="xs"
                 c={hasErrorsTicketInfoForm ? "red" : "black"}
                 truncate="end"
               >
@@ -191,19 +193,19 @@ const ChatExtraInfo = ({
             </Box>
           </Tabs.Tab>
           <Tabs.Tab value="contract">
-            <Text c={hasErrorsContractForm ? "red" : "black"}>
+            <Text size="xs" c={hasErrorsContractForm ? "red" : "black"}>
               {getLanguageByKey("Contract")}
             </Text>
           </Tabs.Tab>
           <Tabs.Tab value="invoice">
-            <Text>{getLanguageByKey("Invoice")}</Text>
+            <Text size="xs">{getLanguageByKey("Invoice")}</Text>
           </Tabs.Tab>
           <Tabs.Tab h="100%" value="media">
-            <Text>{getLanguageByKey("Media")}</Text>
+            <Text size="xs">{getLanguageByKey("Media")}</Text>
           </Tabs.Tab>
 
           <Tabs.Tab value="quality_control">
-            <Text c={hasErrorQualityControl ? "red" : "black"}>
+            <Text size="xs" c={hasErrorQualityControl ? "red" : "black"}>
               {getLanguageByKey("Control calitate")}
             </Text>
           </Tabs.Tab>

--- a/src/Components/ChatComponent/ChatExtraInfo.js
+++ b/src/Components/ChatComponent/ChatExtraInfo.js
@@ -179,34 +179,47 @@ const ChatExtraInfo = ({
       <Tabs defaultValue="general" h="100%">
         <Tabs.List>
           <Tabs.Tab value="general">
-            <Text size="xs">{getLanguageByKey("General")}</Text>
+            <Text fw={700} size="sm">
+              {getLanguageByKey("General")}
+            </Text>
           </Tabs.Tab>
-          <Tabs.Tab value="info">
-            <Box w="100">
-              <Text
-                size="xs"
-                c={hasErrorsTicketInfoForm ? "red" : "black"}
-                truncate="end"
-              >
-                {getLanguageByKey("Informații despre tichet")}
-              </Text>
-            </Box>
+          <Tabs.Tab value="ticket">
+            <Text
+              fw={700}
+              size="sm"
+              c={hasErrorsTicketInfoForm ? "red" : "black"}
+              truncate="end"
+            >
+              {getLanguageByKey("ticket")}
+            </Text>
           </Tabs.Tab>
           <Tabs.Tab value="contract">
-            <Text size="xs" c={hasErrorsContractForm ? "red" : "black"}>
+            <Text
+              fw={700}
+              size="sm"
+              c={hasErrorsContractForm ? "red" : "black"}
+            >
               {getLanguageByKey("Contract")}
             </Text>
           </Tabs.Tab>
           <Tabs.Tab value="invoice">
-            <Text size="xs">{getLanguageByKey("Invoice")}</Text>
+            <Text fw={700} size="sm">
+              {getLanguageByKey("Invoice")}
+            </Text>
           </Tabs.Tab>
           <Tabs.Tab h="100%" value="media">
-            <Text size="xs">{getLanguageByKey("Media")}</Text>
+            <Text fw={700} size="sm">
+              {getLanguageByKey("Media")}
+            </Text>
           </Tabs.Tab>
 
           <Tabs.Tab value="quality_control">
-            <Text size="xs" c={hasErrorQualityControl ? "red" : "black"}>
-              {getLanguageByKey("Control calitate")}
+            <Text
+              fw={700}
+              size="sm"
+              c={hasErrorQualityControl ? "red" : "black"}
+            >
+              {getLanguageByKey("quality")}
             </Text>
           </Tabs.Tab>
         </Tabs.List>
@@ -255,7 +268,7 @@ const ChatExtraInfo = ({
           </Box>
         </Tabs.Panel>
 
-        <Tabs.Panel value="info">
+        <Tabs.Panel value="ticket">
           <Box p="md">
             <TicketInfoForm
               formInstance={form}

--- a/src/Components/ChatComponent/ChatExtraInfo.js
+++ b/src/Components/ChatComponent/ChatExtraInfo.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { MdOutlineAirplaneTicket } from "react-icons/md";
 import { enqueueSnackbar } from "notistack";
 import { Tabs, ScrollArea, Divider, Box, Button, Text } from "@mantine/core";
 import { getLanguageByKey, showServerError } from "../utils";
@@ -183,14 +182,14 @@ const ChatExtraInfo = ({
               {getLanguageByKey("General")}
             </Text>
           </Tabs.Tab>
-          <Tabs.Tab value="ticket">
+          <Tabs.Tab value="lead">
             <Text
               fw={700}
               size="sm"
               c={hasErrorsTicketInfoForm ? "red" : "black"}
               truncate="end"
             >
-              {getLanguageByKey("ticket")}
+              {getLanguageByKey("lead")}
             </Text>
           </Tabs.Tab>
           <Tabs.Tab value="contract">
@@ -268,7 +267,7 @@ const ChatExtraInfo = ({
           </Box>
         </Tabs.Panel>
 
-        <Tabs.Panel value="ticket">
+        <Tabs.Panel value="lead">
           <Box p="md">
             <TicketInfoForm
               formInstance={form}

--- a/src/Components/utils/translations.js
+++ b/src/Components/utils/translations.js
@@ -1931,9 +1931,9 @@ export const translations = {
     RO: "Filtrare după grup lead",
     RU: "Последнее взаимодействие",
   },
-  ticket: {
-    RO: "Ticket",
-    RU: "Заявка",
+  lead: {
+    RO: "Lead",
+    RU: "Лид",
   },
   quality: {
     RO: "Calitate",

--- a/src/Components/utils/translations.js
+++ b/src/Components/utils/translations.js
@@ -1931,4 +1931,12 @@ export const translations = {
     RO: "Filtrare după grup lead",
     RU: "Последнее взаимодействие",
   },
+  ticket: {
+    RO: "Ticket",
+    RU: "Заявка",
+  },
+  quality: {
+    RO: "Calitate",
+    RU: "Качество",
+  },
 };


### PR DESCRIPTION
**Task Links**
[](https://trello.com/c/lFITw8CR/152-extra-info-tabs-from-margin-to-margin)

**Photos**

![image](https://github.com/user-attachments/assets/a02a7d76-f7a9-485e-b0d9-c9b3bd307ecc)
