### PR TITLE
fix: overlap too big text in msj

### DIFF
--- a/src/Components/ChatComponent/utils.js
+++ b/src/Components/ChatComponent/utils.js
@@ -1,12 +1,25 @@
 import { FaRegFileLines } from "react-icons/fa6";
-import { Flex, Text } from "@mantine/core";
+import { Flex, Text, Box } from "@mantine/core";
 import { getLanguageByKey } from "../utils";
+
+const STORAGE_URL = "https://storage.googleapis.com";
+const PDF_FILE = [".pdf"];
 
 export const getMediaType = (mimeType) => {
   if (mimeType.startsWith("image/")) return "image";
   if (mimeType.startsWith("video/")) return "video";
   if (mimeType.startsWith("audio/")) return "audio";
   return "file";
+};
+
+const renderFile = (source) => {
+  return (
+    <a href={source} target="_blank" rel="noopener noreferrer">
+      <Flex c="black">
+        <FaRegFileLines size="24px" />
+      </Flex>
+    </a>
+  );
 };
 
 export const renderContent = (msg) => {
@@ -46,18 +59,22 @@ export const renderContent = (msg) => {
         </audio>
       );
     case "file":
-      return (
-        <a href={msg.message} target="_blank" rel="noopener noreferrer">
-          <Flex c="black">
-            <FaRegFileLines size="24px" />
-          </Flex>
-        </a>
-      );
+      return renderFile(msg.message);
     default:
-      return (
-        <Text style={{ whiteSpace: "pre-line" }} truncate>
-          {msg.message}
-        </Text>
+      const { message } = msg;
+      const isFile =
+        message.startsWith(STORAGE_URL) && message.endsWith(PDF_FILE);
+      return isFile ? (
+        renderFile(message)
+      ) : (
+        <Box maw="600px" w="100%">
+          <Text
+            style={{ whiteSpace: "pre-line", wordWrap: "break-word" }}
+            truncate
+          >
+            {message}
+          </Text>
+        </Box>
       );
   }
 };


### PR DESCRIPTION
**Notes**

- Prevent cases where a message ends with the `.pdf` format, starts with `https://storage.googleapis.com`, and has `mtype` set to `text`.
- Handle cases where the text is too long and overflows, causing it to overlap the parent element

![image](https://github.com/user-attachments/assets/79a05b6c-60d0-4bde-addc-505d54e6d1e3)

**Photos**

![image](https://github.com/user-attachments/assets/39af8c1e-9692-4d1b-8848-ba0b71db12bb)

![image](https://github.com/user-attachments/assets/bb172de1-5140-4ef0-b582-ae2d1913b739)


**Task Links**

[FIX chat-wrapper ON CHAT MESSAGE FILE LINK](https://trello.com/c/aq7XYmZH/198-fix-chat-wrapper-on-chat-message-file-link)
