### PR TITLE
fix: don't send msj when selected client is missing

### DIFF
--- a/src/Components/ChatComponent/components/ChatInput/ChatInput.jsx
+++ b/src/Components/ChatComponent/components/ChatInput/ChatInput.jsx
@@ -106,7 +106,7 @@ export const ChatInput = ({
         <Flex align="center" justify="space-between">
           <Flex gap="xs">
             <Button
-              disabled={!message.trim()}
+              disabled={!message.trim() || !currentClient.payload}
               variant="filled"
               onClick={sendMessage}
             >

--- a/src/Components/ChatComponent/components/ChatMessages/ChatMessages.js
+++ b/src/Components/ChatComponent/components/ChatMessages/ChatMessages.js
@@ -162,7 +162,7 @@ export const ChatMessages = ({
           clientList={messageSendersByPlatform}
           currentClient={selectedClient}
           onSendMessage={(value) => {
-            if (!selectedClient) {
+            if (!selectedClient.payload) {
               return;
             }
             sendMessage(


### PR DESCRIPTION
Description:

When try to send a message and the selected user is missing the page crashes


Before Fix: 

![image](https://github.com/user-attachments/assets/2f50cf4d-b0b5-40d4-958e-d47c6013e618)


After Fix:

![image](https://github.com/user-attachments/assets/b56c1f5d-b723-466c-aeb1-842bef97b846)


